### PR TITLE
expand `~` in allowed paths

### DIFF
--- a/fastaudit/core.py
+++ b/fastaudit/core.py
@@ -146,7 +146,7 @@ def _new_state():
         audit('audit_perms.set_config', oks)
         if on_call and not monitor_calls: raise RuntimeError('on_call requires monitor_calls=True')
         if monitor_calls: install_call_monitor(tool_id)
-        oks = tuple('.' if o=='.' else realpath(fsdecode(o)) for o in oks)
+        oks = tuple('.' if o=='.' else realpath(os.path.expanduser(fsdecode(o))) for o in oks)
         cfg = _AuditCfg(oks, before_deny, on_call, data, monitor_calls)
 
         @contextmanager

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -72,6 +72,18 @@ def test_audit_blocks(tmp_path):
         with expect_fail(PermissionError), permissive(): pass
 
 
+
+def test_expanduser_allowed_path(tmp_path, monkeypatch):
+    home = tmp_path/'home'
+    allowed = home/'allowed'
+    allowed.mkdir(parents=True)
+    monkeypatch.setenv('HOME', str(home))
+    target = allowed/'audit-path-test.txt'
+
+    with mk_audit(('~/allowed',), monitor_calls=False)():
+        touch(target)
+
+    assert target.read_text() == 'x'
 def test_callbacks(tmp_path):
     def before_deny(event, args, frame, msg, data): return event=='subprocess.Popen' and args[1][:1]==['echo']
     def on_call(caller, callee, fn, code, off, data):


### PR DESCRIPTION
Ok paths need to expand the user otherwise we get the error below:

<img width="1853" height="301" alt="image" src="https://github.com/user-attachments/assets/935ed2c8-6e4c-477a-979a-5050aa4f3f17" />

I added a small test and made sure it failed w/o the fix