### PR TITLE
Allow additional dunder attributes in sandbox setattr audit

### DIFF
--- a/fastaudit/core.py
+++ b/fastaudit/core.py
@@ -158,7 +158,7 @@ def _new_state():
         errstr = f"Audit: {event} blocked in sandbox with args: {args}"
         if event not in audit_check: return deny(cfg, event, args, errstr)
         if event=='object.__setattr__':
-            if args[1] in ('__bases__', '__class__', '__defaults__', '__doc__','__module__'): return
+            if args[1] in ('__bases__', '__class__', '__defaults__', '__doc__','__module__','__name__','__qualname__','__code__'): return
             return deny(cfg, event, args, errstr)
         ps = []
         if event=='open':


### PR DESCRIPTION
                                                                                                                                                     
This PR add 3 more elements to the list of permitted attributes for `object.__setattr__` events in the sandbox audit hook.                                               
                                                                                                                                                  
This PR  adds `__name__`, `__qualname__`, and `__code__` to the allowlist of dunder attributes that are permitted through the sandbox for `object.__setattr__` events. 
                                                          
 ## Why                                                                                                     

These attributes are commonly set during normal Python object/function construction and decoration patterns. 

- `qualname` and `name` are mostly cosmetics so it should be fine.
- `code` is more dangerous, but our `@patch` decorator triggers it so I think we should either allow it, or rethink how patch works 

The examples that triggered them

- **\`import PIL\`** — building PIL's \`ModeDescriptor\` class sets \`__qualname__\` via the low-level path, raising \`object.__setattr__ ... '__qualname__'\`.
- **fastcore's \`@patch\`** — re-homing a function onto a class assigns its \`__code__\`, raising \`object.__setattr__ ... '__code__'\`. This breaks importing any library using \`@patch\` (e.g. \`fastllm\`).