### PR TITLE
Stop over-blocking three legitimate sandbox operations

### DIFF
--- a/fastaudit/core.py
+++ b/fastaudit/core.py
@@ -97,11 +97,12 @@ def _new_state():
     def frame_name(f): return f"{f.f_globals.get('__name__')}.{f.f_code.co_qualname}"
 
     def owner_mod(fn, obj):
-        "Find inherited C method owners, e.g. NotebookNode.get -> dict.get."
+        "Module of inherited C method `fn` on `obj`; skip Python overrides so a `super()` call to a builtin (NamedStyleList.append -> list.append) attributes to builtins, not the subclass."
         nm = getattr(fn, '__name__', None)
         if not nm: return
         for cls in type(obj).__mro__:
-            if nm in cls.__dict__: return getattr(cls, '__module__', None)
+            m = cls.__dict__.get(nm)
+            if m is not None and not isinstance(m, types.FunctionType): return getattr(cls, '__module__', None)
 
     def func_mod(fn):
         fn = unwrap_call(fn)
@@ -228,7 +229,7 @@ def _new_state():
             return
         if event not in audit_check: return deny(cfg, event, args, err_msg(event, args))
         if event=='object.__setattr__':
-            if args[1] in ('__qualname__', '__bases__', '__class__', '__defaults__', '__doc__','__module__'): return
+            if args[1] in ('__name__', '__qualname__', '__bases__', '__class__', '__defaults__', '__doc__','__module__'): return
             return deny(cfg, event, args, err_msg(event, args))
         ps = []
         if event=='open':
@@ -246,7 +247,8 @@ def _new_state():
         elif event in audit_dst: ps = [args[1]]
         elif event in audit_both: ps = args[:2]
         for p in ps:
-            if not ok_path(cfg, p, parent=True): deny(cfg, event, args, f"{event} {p!r} not in {cfg.oks}")
+            # NamedTemporaryFile audits open(<dir>,'w+') with the directory as the path, so also accept p itself
+            if not (ok_path(cfg, p, parent=True) or ok_path(cfg, p)): deny(cfg, event, args, f"{event} {p!r} not in {cfg.oks}")
 
     def hook(event, args):
         cfg = ctx.get()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,4 @@
-import asyncio, contextvars, fastaudit.core as core, importlib, nbformat, numpy as np, orjson, os, pytest, regex, shutil, subprocess, sys, threading, traceback
+import asyncio, contextvars, fastaudit.core as core, importlib, nbformat, numpy as np, orjson, os, pytest, regex, shutil, subprocess, sys, tempfile, threading, traceback
 from exhash import exhash_file
 from exhash.exhash import line_hash as native_line_hash
 from fastcore.basics import Self
@@ -82,6 +82,12 @@ def test_audit_blocks(tmp_path):
             def __call__(self): return 'ok'
         assert isinstance(Plain(), Plain)
         assert PyCallable()() == 'ok'
+        # A Python method reaching an inherited C method via super() (openpyxl's
+        # NamedStyleList.append -> list.append) attributes to builtins, not the subclass, so isn't blocked.
+        class MyList(list):
+            def append(self, x): super().append(x)
+        ml = MyList(); ml.append(1)
+        assert ml == [1]
         # fastcore.Self builds chains in __getattr__; call monitoring must not add steps.
         s = Self.split(',')
         state = vars(s).copy()
@@ -114,6 +120,15 @@ def test_audit_blocks(tmp_path):
         with expect_fail(PermissionError), permissive(): pass
 
 
+
+def test_tempfile_in_allowed_dir(tmp_path):
+    # CPython's NamedTemporaryFile passes `dir` as the path argument of `_io.open` (with an opener),
+    # so the audited event is open(<dir>, 'w+') — the directory itself. The parent-lifted check alone
+    # ascends outside the allowed root and denies it; the path's own realpath must also be accepted.
+    with mk_audit([tmp_path], monitor_calls=False)():
+        with tempfile.NamedTemporaryFile(dir=tmp_path) as f: f.write(b'x')
+        with tempfile.TemporaryFile(dir=tmp_path) as f: f.write(b'x')
+        with expect_fail(PermissionError): tempfile.NamedTemporaryFile(dir=expanduser('~'))
 
 def test_expanduser_allowed_path(tmp_path, monkeypatch):
     home = tmp_path/'home'


### PR DESCRIPTION
Three correctness fixes so the sandbox stops denying benign operations. Together they let hosts drop broad `fastaudit_safe_native` trust (e.g. **openpyxl**) and rely on `ok_dests` confinement instead of trusting whole libraries.

## 1. `super()` calls to inherited C methods are misattributed

`owner_mod` walked the MRO by name and returned the **first** class defining that name. But when a Python subclass overrides a C method and reaches the inherited one via `super()`, the actual callee is the C method while the first MRO hit is the subclass's Python override — so the builtin got attributed to the subclass's module.

Concretely, openpyxl 3.1.5 `styles/named_styles.py`:

```python
class NamedStyleList(list):
    def append(self, style):
        if not isinstance(style, NamedStyle): ...
        style._style.xfId = (len(self))
        super().append(style)          # <- this is list.append (builtins)
```

and `packaging/relationship.py`:

```python
class RelationshipList(ElementList):
    def append(self, value):
        super().append(value)          # <- reaches list.append (builtins)
        if not value.Id: value.Id = f"rId{len(self)}"
```

The monitor sees the bound builtin `<built-in method append of NamedStyleList object at 0x…>` — a `builtin_function_or_method` with `__qualname__='NamedStyleList.append'`, `__module__=None`, `__self__` a subclass instance (CPython names a bound builtin after `type(__self__)`, not its defining class). `owner_mod` then matched `append` in `NamedStyleList.__dict__` first and returned `openpyxl.styles.named_styles`, so `is_stdlib_mod` returned False and the call was audited/blocked.

**Fix:** `owner_mod` skips Python-function overrides, so an inherited C method attributes to its real defining module (`builtins`) and is disabled as stdlib. Since `owner_mod` only runs for non-Python callees, a Python override in the MRO is never the true callee — skipping it is strictly more correct.

Effect: openpyxl (and any `list`/`dict` subclass calling `super()`) no longer needs a `fastaudit_safe_native` entry. Verified: with openpyxl removed from `safe_native`, `pandas.to_excel`/`read_excel` work and no openpyxl call is flagged native.

## 2. `NamedTemporaryFile` in an allowed directory

`tempfile.NamedTemporaryFile(dir=…)` / `TemporaryFile(dir=…)` pass the **directory** as the path arg of `_io.open` (with an opener), so the audited event is `open(<dir>, 'w+')`. The parent-lifted `ok_path` then ascends to the dir's parent and denies it. We now also accept the path's own realpath, so a tempdir that is itself in `ok_dests` is allowed — **without** widening `ok_dests` to the tempdir's parent (which would also expose its siblings). Never widens beyond `ok_dests`. Covered by `test_tempfile_in_allowed_dir`.

## 3. `object.__setattr__` of `__name__`

Setting a class's `__name__` raises the `object.__setattr__` audit event, and real libraries in common stacks do it at import/first-use — e.g. `typing`, `numpy._core._exceptions._display_as_base` (renaming its UFunc exception classes), `dateutil.parser.__deprecate_private_class`. `__name__` is added to the metadata allowlist alongside `__qualname__`/`__module__`/`__doc__`.

**Security:** `__name__` is display-only introspection metadata — it doesn't affect identity, `isinstance`, or MRO (safer than `__bases__`/`__class__`, already on the list). It also can't forge an allow-system match: the matcher reads a frame's `f_code.co_qualname` and defining-module `__name__`, never the settable `__name__`/`__qualname__`/`__module__`. Verified with an attack that forges those attributes to mimic `pandas.DataFrame` — the write is still denied and the matcher sees the real frame identity.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
